### PR TITLE
Migrate Profile::updateOrCreate to v5 API, fix Table parenthesis bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## 2.0.0
+### Breaking Changes
+- `Profile::updateOrCreate()` migrated to v5 API (`PUT v5/entities/.../profile-tables/.../profiles`)
+  - Payload format changed: `attributes` is now a flat `{key: value}` object (was an array of `{name, value}`)
+  - Subscriptions format changed: flat `{name: bool}` object (was an array of `{name, subscribe}`)
+  - A `key` field is now required and auto-detected from `emailAddress` or `userId` in attributes
+### Fixed
+- `Table::all()` and `Table::find()` had a misplaced parenthesis in the `config()` call that produced broken URLs
+### Notes
+- `Profile::find()`, `firstOrCreate()`, `delete()`, `subscribe()`, `unsubscribe()`, `subscriptions()` still use v4 endpoints — pending full v5 migration
+
 ## 1.0.4
 ### What's Changed
 - Caching the authorization token for 14 minutes (15 minutes is the default Actito validity)

--- a/src/Endpoints/Profile.php
+++ b/src/Endpoints/Profile.php
@@ -42,33 +42,33 @@ class Profile
     }
 
     /**
-     * @link https://developers.actito.com/api-reference/data-v4#operation/profiles-createorupdate
+     * @link https://developers.actito.com/api-reference/data-v5/#operation/profiles-createorupdate
      */
     public function updateOrCreate(array $data): Response
     {
-        $payload = [];
+        $attributes = $data['attributes'] ?? $data;
 
-        if (! isset($data['attributes'])) {
-            $data['attributes'] = $data;
-        }
+        $payload = ['attributes' => $attributes];
 
-        foreach ($data['attributes'] as $key => $value) {
-            $payload['attributes'][] = [
-                'name' => $key,
-                'value' => $value,
-            ];
+        // v5 requires a key field to identify the profile for upsert.
+        // Explicit key takes priority, then we fall back to known business keys.
+        if (isset($data['key'])) {
+            $payload['key'] = $data['key'];
+        } elseif (isset($attributes['emailAddress'])) {
+            $payload['key'] = ['emailAddress' => $attributes['emailAddress']];
+        } elseif (isset($attributes['userId'])) {
+            $payload['key'] = ['userId' => $attributes['userId']];
         }
 
         if (isset($data['subscriptions'])) {
-            foreach ($data['subscriptions'] as $key => $value) {
-                $payload['subscriptions'][] = [
-                    'name' => $key,
-                    'subscribe' => $value,
-                ];
-            }
+            // v5 expects a flat object {"SubscriptionName": true|false}
+            $payload['subscriptions'] = $data['subscriptions'];
         }
 
-        return $this->client->post('v4/entity/'.config('actito.entity').'/table/'.config('actito.profile_table').'/profile', $payload);
+        return $this->client->put(
+            'v5/entities/'.config('actito.entity').'/profile-tables/'.config('actito.profile_table').'/profiles',
+            $payload
+        );
     }
 
     /**

--- a/src/Endpoints/Table.php
+++ b/src/Endpoints/Table.php
@@ -22,7 +22,7 @@ class Table
             $params = '?'.Arr::query($queryParameters);
         }
 
-        return $this->client->get('v4/entity/'.config('actito.entity'.'/customTable/'.$table.'/record'.$params));
+        return $this->client->get('v4/entity/'.config('actito.entity').'/customTable/'.$table.'/record'.$params);
     }
 
     /**
@@ -30,7 +30,7 @@ class Table
      */
     public function find(string $table, string $businessKey): Response
     {
-        return $this->client->get('v4/entity/'.config('actito.entity'.'/customTable/'.$table.'/record/'.$businessKey));
+        return $this->client->get('v4/entity/'.config('actito.entity').'/customTable/'.$table.'/record/'.$businessKey);
     }
 
     /**


### PR DESCRIPTION
- Profile::updateOrCreate now uses PUT v5/entities/.../profile-tables/.../profiles with flat attributes object and auto-detected key (emailAddress > userId)
- Subscriptions no longer transformed to [{name,subscribe}] array — v5 expects flat {name: bool} object which callers already provide
- Table::all() and Table::find() had config() parenthesis in wrong position, producing broken URLs (config key included the path instead of just the key)
- Other Profile methods (find, delete, subscribe, unsubscribe) remain on v4 pending full migration (find response format change would break SendInvitationListener)